### PR TITLE
Add terrain edge unit test and Node test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "lunarlanderwebapp",
+  "version": "1.0.0",
+  "description": "This repository contains a simple web version of the **Lunar Lander** game. It simulates the lunar module descent phase of the Apollo missions. The objective is to land the module safely on the Moon’s surface by controlling a single thruster.",
+  "main": "script.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/script.js
+++ b/script.js
@@ -101,8 +101,14 @@ function getTerrainYPixel(xPix) {
   if (terrainPoints.length === 0) return canvas.height;
   const numSegments = terrainPoints.length - 1;
   const segmentWidth = canvas.width / numSegments;
-  const i = Math.floor(xPix / segmentWidth);
-  const t = (xPix % segmentWidth) / segmentWidth;
+  // Clamp xPix to the canvas bounds so we don't read past the last segment
+  const clampedX = Math.min(Math.max(xPix, 0), canvas.width);
+  let i = Math.floor(clampedX / segmentWidth);
+  let t = (clampedX % segmentWidth) / segmentWidth;
+  if (i >= numSegments) {
+    i = numSegments - 1;
+    t = 1;
+  }
   const h0 = terrainPoints[i];
   const h1 = terrainPoints[i + 1];
   const heightNorm = h0 * (1 - t) + h1 * t;
@@ -513,3 +519,14 @@ if (btnRight) {
 
 // Physics update timer (10 updates per second)
 setInterval(updatePhysics, 100);
+
+// Export functions for testing in Node environments
+if (typeof module !== 'undefined') {
+  module.exports = {
+    getTerrainYPixel,
+    setTerrainPoints: (points) => {
+      terrainPoints = points;
+    },
+    canvas,
+  };
+}

--- a/tests/terrain.test.js
+++ b/tests/terrain.test.js
@@ -1,0 +1,20 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+// Minimal DOM stubs required by script.js
+const canvas = { width: 200, height: 100, getContext: () => ({}) };
+const restartButton = { addEventListener: () => {} };
+
+global.document = {
+  getElementById: (id) => ({ gameCanvas: canvas, restartButton }[id] || null),
+  addEventListener: () => {},
+};
+
+const { getTerrainYPixel, setTerrainPoints, canvas: scriptCanvas } = require('../script.js');
+
+test('getTerrainYPixel returns a finite number at canvas width', () => {
+  setTerrainPoints([0.1, 0.2, 0.3]);
+  const y = getTerrainYPixel(scriptCanvas.width);
+  assert.strictEqual(typeof y, 'number');
+  assert.ok(!Number.isNaN(y));
+});


### PR DESCRIPTION
## Summary
- add Node-based test verifying `getTerrainYPixel` handles canvas edge and returns a valid number
- clamp `getTerrainYPixel` x coordinate and export helpers for testing
- add package.json with `test` script and ignore node_modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9710c8844832cbc066826ced593ff