### PR TITLE
perf: throttle canvas resize handler

### DIFF
--- a/script.js
+++ b/script.js
@@ -574,6 +574,17 @@ function resizeCanvas() {
   game.canvas.style.height = `${maxHeight * scale}px`;
 }
 
-window.addEventListener('resize', resizeCanvas);
+let resizeRaf = null;
+function handleResize() {
+  if (resizeRaf !== null) {
+    cancelAnimationFrame(resizeRaf);
+  }
+  resizeRaf = requestAnimationFrame(() => {
+    resizeRaf = null;
+    resizeCanvas();
+  });
+}
+
+window.addEventListener('resize', handleResize);
 resizeCanvas();
 


### PR DESCRIPTION
## Summary
- debounce canvas resize with requestAnimationFrame
- expose named resize handler for potential removal

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa47c70424832cac49df8d9d8e7b07