### PR TITLE
Add Node-based unit tests for Lander physics

### DIFF
--- a/__tests__/lander.test.js
+++ b/__tests__/lander.test.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { Lander, CONFIG } = require('../lander');
+
+test('fuel decreases when thrusters fire', () => {
+  const lander = new Lander(100);
+  lander.reset(10);
+  lander.startUp();
+  lander.update(1, 0, 1, 0);
+  assert.strictEqual(lander.fuel, 9);
+});
+
+test('thrusters stop when fuel runs out', () => {
+  const lander = new Lander(100);
+  lander.reset(1);
+  lander.startUp();
+  lander.update(1, 0, 1, 0);
+  assert.strictEqual(lander.upThruster, false);
+});
+
+test('position updates according to velocity', () => {
+  const lander = new Lander(100);
+  lander.reset(0);
+  lander.verticalVelocity = 10;
+  lander.horizontalVelocity = 5;
+  lander.update(1, 0, 0, 0);
+  assert.ok(Math.abs(lander.altitude - (CONFIG.maxAltitude - 10)) < 1e-6);
+  assert.ok(Math.abs(lander.horizontalPosition - (50 + 5)) < 1e-6);
+});

--- a/lander.js
+++ b/lander.js
@@ -1,0 +1,82 @@
+const CONFIG = {
+  maxAltitude: 100.0
+};
+
+class Lander {
+  constructor(maxRange) {
+    this.maxRange = maxRange;
+    this.reset(0);
+  }
+
+  reset(startFuel) {
+    this.altitude = CONFIG.maxAltitude;
+    this.verticalVelocity = 0.0;
+    this.horizontalPosition = this.maxRange / 2;
+    this.horizontalVelocity = 0.0;
+    this.fuel = startFuel;
+    this.upThruster = false;
+    this.leftThruster = false;
+    this.rightThruster = false;
+  }
+
+  startUp() {
+    if (this.fuel > 0) this.upThruster = true;
+  }
+  stopUp() {
+    this.upThruster = false;
+  }
+  startLeft() {
+    if (this.fuel > 0) this.leftThruster = true;
+  }
+  stopLeft() {
+    this.leftThruster = false;
+  }
+  startRight() {
+    if (this.fuel > 0) this.rightThruster = true;
+  }
+  stopRight() {
+    this.rightThruster = false;
+  }
+
+  update(dt, gravity, mainThrust, sideThrust) {
+    let accelY = gravity;
+    let accelX = 0;
+    let thrusters = 0;
+
+    if (this.upThruster && this.fuel > 0) {
+      accelY -= mainThrust;
+      thrusters++;
+    }
+    if (this.leftThruster && this.fuel > 0) {
+      accelX -= sideThrust;
+      thrusters++;
+    }
+    if (this.rightThruster && this.fuel > 0) {
+      accelX += sideThrust;
+      thrusters++;
+    }
+
+    if (thrusters > 0 && this.fuel > 0) {
+      this.fuel = Math.max(this.fuel - thrusters, 0);
+      if (this.fuel <= 0) {
+        this.upThruster = this.leftThruster = this.rightThruster = false;
+      }
+    }
+
+    this.verticalVelocity += accelY * dt;
+    this.horizontalVelocity += accelX * dt;
+
+    this.altitude -= this.verticalVelocity * dt;
+    this.horizontalPosition += this.horizontalVelocity * dt;
+
+    if (this.horizontalPosition < 0) {
+      this.horizontalPosition = 0;
+      this.horizontalVelocity = 0;
+    } else if (this.horizontalPosition > this.maxRange) {
+      this.horizontalPosition = this.maxRange;
+      this.horizontalVelocity = 0;
+    }
+  }
+}
+
+module.exports = { Lander, CONFIG };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "lunarlanderwebapp",
+  "version": "1.0.0",
+  "description": "This repository contains a simple web version of the Lunar Lander game.",
+  "main": "script.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- set up npm test script using Node's built-in test runner
- add Lander module and basic physics tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa483cde40832c9566033da7404c0c