### PR TITLE
Make status indicators compact

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,17 +27,16 @@
   <div id="gameContainer" class="hidden" role="main">
   <!-- Canvas element where the lander and thrusters are drawn -->
   <canvas id="gameCanvas" width="360" height="480" aria-label="Game canvas"></canvas>
-  <!-- Status readout overlaid on the game area -->
-  <div id="status">
-    <p id="altitude">Altitude: 100.0 m</p>
-    <p id="vVelocity">Vertical Velocity: 0.0 m/s</p>
-    <p id="hVelocity">Horizontal Velocity: 0.0 m/s</p>
-    <p id="fuel">Fuel: 1000</p>
-    <!-- Current level is displayed here and updated by the script -->
-    <p id="level">Level: 1</p>
+    <!-- Compact status indicators overlaid on the game area -->
+    <div id="status">
+      <p id="altitude">ALT 100m</p>
+      <p id="vVelocity">VV 0m/s</p>
+      <p id="hVelocity">HV 0m/s</p>
+      <p id="fuel">FUEL 1000</p>
+      <p id="level">LVL 1</p>
+    </div>
     <!-- Message displayed at end of game -->
     <p id="message"></p>
-  </div>
   <!-- Buttons displayed after the game ends: restart and share.  They are wrapped in
        a container so they can be centrally positioned over the game area.  The
        container is hidden by default and shown when the game ends. -->

--- a/script.js
+++ b/script.js
@@ -259,12 +259,12 @@ class Game {
 
   // Update textual status on the page
   updateUI() {
-    this.altitudeElem.textContent = `Altitude: ${this.lander.altitude.toFixed(1)} m`;
-    this.vVelElem.textContent = `Vertical Velocity: ${this.lander.verticalVelocity.toFixed(1)} m/s`;
-    this.hVelElem.textContent = `Horizontal Velocity: ${this.lander.horizontalVelocity.toFixed(1)} m/s`;
-    this.fuelElem.textContent = `Fuel: ${Math.floor(this.lander.fuel)}`;
+    this.altitudeElem.textContent = `ALT ${this.lander.altitude.toFixed(1)}m`;
+    this.vVelElem.textContent = `VV ${this.lander.verticalVelocity.toFixed(1)}m/s`;
+    this.hVelElem.textContent = `HV ${this.lander.horizontalVelocity.toFixed(1)}m/s`;
+    this.fuelElem.textContent = `FUEL ${Math.floor(this.lander.fuel)}`;
+    this.levelElem.textContent = `LVL ${this.level}`;
     this.messageElem.textContent = this.message;
-    this.levelElem.textContent = `Level: ${this.level}`;
   }
 
   // Draw the lander, ground and thruster flames on the canvas

--- a/style.css
+++ b/style.css
@@ -35,21 +35,30 @@ h1 {
 
 #status {
   position: absolute;
-  top: 10px;
-  left: 50%;
-  transform: translateX(-50%);
+  top: 5px;
+  left: 5px;
   display: flex;
-  gap: 10px;
-  padding: 4px 8px;
-  background-color: rgba(10, 10, 35, 0.7);
-  border-radius: 4px;
+  flex-wrap: wrap;
+  gap: 4px;
   z-index: 2;
-  font-size: 12px;
 }
 
 #status p {
   margin: 0;
-  font-size: 12px;
+  padding: 2px 4px;
+  font-size: 10px;
+  background-color: rgba(10, 10, 35, 0.7);
+  border-radius: 4px;
+}
+
+#message {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2;
+  margin: 0;
+  font-size: 14px;
 }
 
 button {


### PR DESCRIPTION
## Summary
- Show altitude, velocities, fuel and level as small abbreviated labels so all HUD info fits on screen
- Wrap and style status items into compact boxes and position message separately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa4cd41a18832c9f85449b106691a8