### PR TITLE
Prevent long-press text selection and zoom on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <title>Lunar Lander Web App</title>
   <!-- Include the stylesheet for layout and canvas styling -->
   <link rel="stylesheet" href="style.css" />

--- a/style.css
+++ b/style.css
@@ -73,6 +73,12 @@ button {
   transition: background-color 0.3s ease, box-shadow 0.3s ease;
   /* Neon glow */
   box-shadow: 0 0 5px #ff00a0, 0 0 10px #ff00a0;
+  /* Prevent long‑press text selection/zoom on mobile */
+  user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  -webkit-touch-callout: none;
+  touch-action: manipulation;
 }
 
 button:hover {


### PR DESCRIPTION
## Summary
- disable text selection and double-tap zoom on buttons for mobile devices
- prevent viewport scaling to avoid unintended zoom

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4ebffeb8832c9013c2f71736eb8a