### PR TITLE
Prevent mobile arrow buttons from text-selection

### DIFF
--- a/style.css
+++ b/style.css
@@ -117,6 +117,9 @@ button:disabled {
   justify-content: center;
   gap: 20px;
   margin-top: 20px;
+  /* Prevent mobile browsers from selecting control text */
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 #mobileControls button {
@@ -130,6 +133,11 @@ button:disabled {
   cursor: pointer;
   transition: background-color 0.3s ease, box-shadow 0.3s ease;
   box-shadow: 0 0 5px #ff00a0, 0 0 10px #ff00a0;
+  /* Ensure arrows inside buttons aren't selectable */
+  user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  -webkit-touch-callout: none;
 }
 
 #mobileControls button:active {


### PR DESCRIPTION
## Summary
- Disable text selection for on-screen arrow controls so touches don't highlight the arrows on mobile.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4fc3c0c4832cbfe31806d47b9acf