### PR TITLE
Add selectable landers at game start

### DIFF
--- a/__tests__/lander.test.js
+++ b/__tests__/lander.test.js
@@ -27,3 +27,8 @@ test('position updates according to velocity', () => {
   assert.ok(Math.abs(lander.altitude - (CONFIG.maxAltitude - 10)) < 1e-6);
   assert.ok(Math.abs(lander.horizontalPosition - (50 + 5)) < 1e-6);
 });
+
+test('constructor stores lander type', () => {
+  const lander = new Lander(100, 'triangle');
+  assert.strictEqual(lander.type, 'triangle');
+});

--- a/index.html
+++ b/index.html
@@ -23,6 +23,28 @@
     <button id="creditsButton" aria-label="Show credits">Credits</button>
   </div>
 
+  <!-- Lander selection shown after clicking play -->
+  <div id="landerSelection" class="hidden" role="menu">
+    <p>Seleziona il tuo lander</p>
+    <div id="landerOptions">
+      <button class="landerChoice" data-type="classic" aria-label="Lander classico">
+        <svg width="40" height="40">
+          <rect x="10" y="5" width="20" height="30" fill="#dcdcdc" />
+        </svg>
+      </button>
+      <button class="landerChoice" data-type="round" aria-label="Lander rotondo">
+        <svg width="40" height="40">
+          <circle cx="20" cy="20" r="15" fill="#dcdcdc" />
+        </svg>
+      </button>
+      <button class="landerChoice" data-type="triangle" aria-label="Lander triangolare">
+        <svg width="40" height="40">
+          <polygon points="20,5 35,35 5,35" fill="#dcdcdc" />
+        </svg>
+      </button>
+    </div>
+  </div>
+
   <!-- The gameContainer wraps the canvas, status, controls and instructions so it can be captured as a single image -->
   <div id="gameContainer" class="hidden" role="main">
   <!-- Canvas element where the lander and thrusters are drawn -->

--- a/src/game.js
+++ b/src/game.js
@@ -89,14 +89,24 @@ class Game {
     this.btnLeft = document.getElementById('btnLeft');
     this.btnRight = document.getElementById('btnRight');
 
-    // Lander instance
-    this.lander = new Lander(CONFIG.maxRange);
+    // Lander instance. The specific lander type can be chosen from the menu
+    // before the game starts. Default to the classic rectangular lander.
+    this.landerType = 'classic';
+    this.lander = new Lander(CONFIG.maxRange, this.landerType);
 
     // Bind restart button
     this.restartButton.addEventListener('click', () => this.restartGame());
 
     this.updateUI();
     this.draw();
+  }
+
+  // Change the currently active lander type and create a new instance. This
+  // is used when the player selects a lander from the menu before starting
+  // the game.
+  setLanderType(type) {
+    this.landerType = type;
+    this.lander = new Lander(CONFIG.maxRange, type);
   }
 
   /*
@@ -210,12 +220,35 @@ class Game {
       this.ctx.lineTo(xPix - CONFIG.landerWidth / 2, yPix - collapsedHeight / 2);
       this.ctx.stroke();
     } else {
-      this.ctx.fillRect(
-        xPix - CONFIG.landerWidth / 2,
-        yPix - CONFIG.landerHeight,
-        CONFIG.landerWidth,
-        CONFIG.landerHeight
-      );
+      // Draw different lander shapes based on the selected type
+      switch (this.lander.type) {
+        case 'round':
+          this.ctx.beginPath();
+          this.ctx.arc(
+            xPix,
+            yPix - CONFIG.landerHeight / 2,
+            CONFIG.landerHeight / 2,
+            0,
+            Math.PI * 2
+          );
+          this.ctx.fill();
+          break;
+        case 'triangle':
+          this.ctx.beginPath();
+          this.ctx.moveTo(xPix, yPix - CONFIG.landerHeight);
+          this.ctx.lineTo(xPix + CONFIG.landerWidth / 2, yPix);
+          this.ctx.lineTo(xPix - CONFIG.landerWidth / 2, yPix);
+          this.ctx.closePath();
+          this.ctx.fill();
+          break;
+        default:
+          this.ctx.fillRect(
+            xPix - CONFIG.landerWidth / 2,
+            yPix - CONFIG.landerHeight,
+            CONFIG.landerWidth,
+            CONFIG.landerHeight
+          );
+      }
     }
 
     // Main thruster flame (drawn below the lander) when firing
@@ -453,15 +486,27 @@ const instructionsModal = document.getElementById('instructionsModal');
 const creditsModal = document.getElementById('creditsModal');
 const closeInstructionsBtn = document.getElementById('closeInstructions');
 const closeCreditsBtn = document.getElementById('closeCredits');
+const landerSelection = document.getElementById('landerSelection');
+const landerButtons = document.querySelectorAll('.landerChoice');
 
 if (playButton) {
   playButton.addEventListener('click', () => {
     if (menu) menu.classList.add('hidden');
+    if (landerSelection) landerSelection.classList.remove('hidden');
+  });
+}
+
+// Handle player choice of lander type after clicking play
+landerButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const type = btn.getAttribute('data-type');
+    game.setLanderType(type);
+    if (landerSelection) landerSelection.classList.add('hidden');
     const gameContainer = document.getElementById('gameContainer');
     if (gameContainer) gameContainer.classList.remove('hidden');
     game.restartGame();
   });
-}
+});
 
 [
   { button: instructionsButton, modal: instructionsModal },

--- a/src/lander.js
+++ b/src/lander.js
@@ -3,8 +3,11 @@ const CONFIG = {
 };
 
 class Lander {
-  constructor(maxRange) {
+  constructor(maxRange, type = 'classic') {
     this.maxRange = maxRange;
+    // Store the visual/physical variant of the lander.  For now the type only
+    // affects rendering but in the future it will influence physics as well.
+    this.type = type;
     this.reset(0);
   }
 

--- a/style.css
+++ b/style.css
@@ -234,6 +234,29 @@ button:disabled {
   box-shadow: 0 0 10px #ff33b5, 0 0 20px #ff33b5;
 }
 
+/* Lander selection screen */
+#landerSelection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 15px;
+  margin-top: 40px;
+}
+
+#landerOptions {
+  display: flex;
+  gap: 20px;
+}
+
+#landerOptions button {
+  width: 60px;
+  height: 60px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* Modal overlay styling */
 .modal {
   position: fixed;


### PR DESCRIPTION
## Summary
- Allow player to choose one of three lander shapes after pressing Play
- Persist chosen lander across levels and draw its shape accordingly
- Add tests for lander type handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aabfbc6860832c955b7003e09b6304