### PR TITLE
fix: avoid global config name collision

### DIFF
--- a/__tests__/lander.test.js
+++ b/__tests__/lander.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { Lander, CONFIG } = require('../src/lander');
+const { Lander, LANDER_CONFIG } = require('../src/lander');
 
 test('fuel decreases when thrusters fire', () => {
   const lander = new Lander(100);
@@ -24,7 +24,7 @@ test('position updates according to velocity', () => {
   lander.verticalVelocity = 10;
   lander.horizontalVelocity = 5;
   lander.update(1, 0, 0, 0);
-  assert.ok(Math.abs(lander.altitude - (CONFIG.maxAltitude - 10)) < 1e-6);
+  assert.ok(Math.abs(lander.altitude - (LANDER_CONFIG.maxAltitude - 10)) < 1e-6);
   assert.ok(Math.abs(lander.horizontalPosition - (50 + 5)) < 1e-6);
 });
 

--- a/src/lander.js
+++ b/src/lander.js
@@ -1,4 +1,7 @@
-const CONFIG = {
+// Configuration specific to the lander model.  Naming this object uniquely
+// avoids clashing with other global constants when the script is included in
+// a browser environment alongside additional scripts such as game logic.
+const LANDER_CONFIG = {
   maxAltitude: 100.0
 };
 
@@ -12,7 +15,7 @@ class Lander {
   }
 
   reset(startFuel) {
-    this.altitude = CONFIG.maxAltitude;
+    this.altitude = LANDER_CONFIG.maxAltitude;
     this.verticalVelocity = 0.0;
     this.horizontalPosition = this.maxRange / 2;
     this.horizontalVelocity = 0.0;
@@ -84,8 +87,10 @@ class Lander {
 
 // Export for Node and attach to window for browser usage
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { Lander, CONFIG };
+  // Export the configuration with a descriptive name to avoid collisions when
+  // required from Node-based tests.
+  module.exports = { Lander, LANDER_CONFIG };
 } else {
   window.Lander = Lander;
-  window.LANDER_CONFIG = CONFIG;
+  window.LANDER_CONFIG = LANDER_CONFIG;
 }


### PR DESCRIPTION
## Summary
- rename lander configuration to LANDER_CONFIG to avoid clashing with game config
- update unit tests to use LANDER_CONFIG

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aac12e5c94832ca206b1a21597aa7e