### PR TITLE
Improve mobile lander selection layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -241,11 +241,15 @@ button:disabled {
   align-items: center;
   gap: 15px;
   margin-top: 40px;
+  width: 100%;
 }
 
 #landerOptions {
   display: flex;
   gap: 20px;
+  flex-wrap: wrap;
+  justify-content: center;
+  width: 100%;
 }
 
 #landerOptions button {
@@ -269,6 +273,14 @@ button:disabled {
   font-size: 10px;
   text-align: center;
   line-height: 1.4;
+}
+
+/* Stack lander options vertically on small screens */
+@media (max-width: 480px) {
+  #landerOptions {
+    flex-direction: column;
+    align-items: center;
+  }
 }
 
 /* Modal overlay styling */


### PR DESCRIPTION
## Summary
- Ensure lander selection screen fits mobile viewports by wrapping options and centering
- Stack lander choices vertically on very small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aac510c780832ca7d7e369aacfb90e