### PR TITLE
Add lander mass property to gameplay and UI

### DIFF
--- a/__tests__/lander.test.js
+++ b/__tests__/lander.test.js
@@ -61,3 +61,8 @@ test('thrust is more effective with lower mass', () => {
   const lightVel = light.verticalVelocity;
   assert.ok(Math.abs(lightVel) > Math.abs(heavyVel));
 });
+
+test('lander accepts custom dry mass', () => {
+  const lander = new Lander(100, 'classic', 1500);
+  assert.strictEqual(lander.mass, 1500);
+});

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
         </button>
         <p class="landerInfo">
           Carburante: 1000<br />
+          Massa: 1000<br />
           Spinta principale: 6<br />
           Spinta laterale: 3<br />
           Qualità: Equilibrato e affidabile<br />
@@ -49,6 +50,7 @@
         </button>
         <p class="landerInfo">
           Carburante: 1200<br />
+          Massa: 1100<br />
           Spinta principale: 5.5<br />
           Spinta laterale: 2.5<br />
           Qualità: Grande autonomia<br />
@@ -63,6 +65,7 @@
         </button>
         <p class="landerInfo">
           Carburante: 800<br />
+          Massa: 900<br />
           Spinta principale: 7<br />
           Spinta laterale: 4<br />
           Qualità: Molto agile<br />

--- a/src/game.js
+++ b/src/game.js
@@ -23,9 +23,9 @@ const CONFIG = {
 // and are also shown in the selection menu to highlight strengths and
 // weaknesses.
 const LANDER_TYPES = {
-  classic: { baseFuel: 1000, mainThrust: 6.0, sideThrust: 3.0 },
-  round: { baseFuel: 1200, mainThrust: 5.5, sideThrust: 2.5 },
-  triangle: { baseFuel: 800, mainThrust: 7.0, sideThrust: 4.0 }
+  classic: { baseFuel: 1000, mainThrust: 6.0, sideThrust: 3.0, dryMass: 1000 },
+  round: { baseFuel: 1200, mainThrust: 5.5, sideThrust: 2.5, dryMass: 1100 },
+  triangle: { baseFuel: 800, mainThrust: 7.0, sideThrust: 4.0, dryMass: 900 }
 };
 
 // Simple audio helpers
@@ -105,7 +105,8 @@ class Game {
     this.mainThrust = this.landerStats.mainThrust;
     this.sideThrust = this.landerStats.sideThrust;
     this.baseFuel = this.landerStats.baseFuel;
-    this.lander = new Lander(CONFIG.maxRange, this.landerType);
+    this.dryMass = this.landerStats.dryMass;
+    this.lander = new Lander(CONFIG.maxRange, this.landerType, this.dryMass);
 
     // Bind restart button
     this.restartButton.addEventListener('click', () => this.restartGame());
@@ -123,7 +124,8 @@ class Game {
     this.mainThrust = this.landerStats.mainThrust;
     this.sideThrust = this.landerStats.sideThrust;
     this.baseFuel = this.landerStats.baseFuel;
-    this.lander = new Lander(CONFIG.maxRange, type);
+    this.dryMass = this.landerStats.dryMass;
+    this.lander = new Lander(CONFIG.maxRange, type, this.dryMass);
   }
 
   /*

--- a/src/lander.js
+++ b/src/lander.js
@@ -7,18 +7,19 @@ const LANDER_CONFIG = {
 
 // Approximate dry mass of the lander (arbitrary units). The total mass
 // is this dry mass plus remaining fuel. As fuel burns, the mass decreases
-// which makes the thrusters more effective.
-const DRY_MASS = 1000;
+// which makes the thrusters more effective. Individual lander models can
+// override this default value.
+const DEFAULT_DRY_MASS = 1000;
 
 class Lander {
-  constructor(maxRange, type = 'classic') {
+  constructor(maxRange, type = 'classic', dryMass = DEFAULT_DRY_MASS) {
     this.maxRange = maxRange;
     // Store the visual/physical variant of the lander.  For now the type only
     // affects rendering but in the future it will influence physics as well.
     this.type = type;
     // Mass properties. `fullMass` will hold the mass when fuel is full so we
     // can scale thrust effectiveness based on current mass.
-    this.dryMass = DRY_MASS;
+    this.dryMass = dryMass;
     this.fullMass = this.dryMass;
     this.mass = this.dryMass;
     this.reset(0);


### PR DESCRIPTION
## Summary
- Allow each lander to define its own dry mass
- Pass lander mass through game logic and display in selection menu
- Add test verifying custom dry mass support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aac8586978832cbaa0e7d3ab914c86