### PR TITLE
Scale fuel consumption with elapsed time

### DIFF
--- a/__tests__/lander.test.js
+++ b/__tests__/lander.test.js
@@ -38,8 +38,7 @@ test('mass decreases as fuel burns', () => {
   lander.reset(10);
   const initialMass = lander.mass;
   lander.startUp();
-  // Burn fuel without advancing time to isolate mass change
-  lander.update(0, 0, 1, 0);
+  lander.update(1, 0, 1, 0);
   assert.strictEqual(lander.mass, initialMass - 1);
 });
 
@@ -52,10 +51,8 @@ test('thrust is more effective with lower mass', () => {
 
   const light = new Lander(100);
   light.reset(1000);
-  for (let i = 0; i < 999; i++) {
-    light.startUp();
-    light.update(0, 0, 1, 0);
-  }
+  light.fuel = 1;
+  light.mass = light.dryMass + light.fuel;
   light.startUp();
   light.update(1, 0, 1, 0);
   const lightVel = light.verticalVelocity;

--- a/src/lander.js
+++ b/src/lander.js
@@ -79,7 +79,9 @@ class Lander {
     }
 
     if (thrusters > 0 && this.fuel > 0) {
-      this.fuel = Math.max(this.fuel - thrusters, 0);
+      // Consume fuel in proportion to active thrusters and elapsed time
+      const fuelUsed = thrusters * dt;
+      this.fuel = Math.max(this.fuel - fuelUsed, 0);
       this.mass = this.dryMass + this.fuel;
       if (this.fuel <= 0) {
         this.upThruster = this.leftThruster = this.rightThruster = false;


### PR DESCRIPTION
## Summary
- Consume fuel based on thruster activity and elapsed time
- Adjust tests to account for time-scaled fuel usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aadfa06e68832cbafbe3b8584fd625