### PR TITLE
fix(npm): use npmjs registry by default; scope GitHub Packages to @your-org

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,23 @@
+name: Node CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Uncomment this block only if we have private packages under @your-org
+      #- run: |
+      #    echo "@your-org:registry=https://npm.pkg.github.com" >> .npmrc
+      #    echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: scripts/verify-registry.sh
+
+      - run: npm ci

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/scripts/verify-registry.sh
+++ b/scripts/verify-registry.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+npm config get registry
+npm ping --registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary
- default npm registry set to npmjs and optional scoped settings for `@your-org`
- add Node CI workflow that sets npm registry, verifies it, and runs `npm ci`
- add `scripts/verify-registry.sh` sanity check

## Testing
- `scripts/verify-registry.sh` *(fails: 403 Forbidden - GET https://registry.npmjs.org/-/ping)*
- `npm ci` *(fails: The `npm ci` command can only install with an existing package-lock.json or...)*
- `npm install express@4.18.2 terser@5.21.0` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaedf4bad4832c94988f64772d252c