### PR TITLE
Reorder language selector and adjust layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,9 @@
 
   <!-- Main menu shown before the game starts -->
     <div id="menu" role="menu">
+      <button id="playButton" aria-label="Play game" data-i18n="play" data-i18n-aria-label="play">Play</button>
+      <button id="instructionsButton" aria-label="Show instructions" data-i18n="instructions" data-i18n-aria-label="instructions">Instructions</button>
+      <button id="creditsButton" aria-label="Show credits" data-i18n="credits" data-i18n-aria-label="credits">Credits</button>
       <div id="languageMenu">
         <label for="languageSelect" data-i18n="language">Language</label>
         <select id="languageSelect" aria-label="Select language">
@@ -26,9 +29,6 @@
           <option value="de">Deutsch</option>
         </select>
       </div>
-      <button id="playButton" aria-label="Play game" data-i18n="play" data-i18n-aria-label="play">Play</button>
-      <button id="instructionsButton" aria-label="Show instructions" data-i18n="instructions" data-i18n-aria-label="instructions">Instructions</button>
-      <button id="creditsButton" aria-label="Show credits" data-i18n="credits" data-i18n-aria-label="credits">Credits</button>
     </div>
 
   <!-- Lander selection shown after clicking play -->

--- a/style.css
+++ b/style.css
@@ -236,8 +236,8 @@ button:disabled {
 
 #languageMenu {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
   gap: 10px;
 }
 


### PR DESCRIPTION
## Summary
- Place language selector at bottom of main menu
- Stack language label above dropdown for clearer layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5e63e258832cbea787d93d25c6a7