### PR TITLE
feat: auto-detect browser language

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -157,7 +157,18 @@ var translations = {
   }
 };
 
-var currentLang = 'en';
+var currentLang = (function() {
+  var userLang = (navigator.languages && navigator.languages[0]) ||
+                 navigator.language ||
+                 navigator.userLanguage;
+  if (userLang) {
+    userLang = userLang.toLowerCase().split('-')[0];
+    if (translations[userLang]) {
+      return userLang;
+    }
+  }
+  return 'en';
+})();
 
 function setLanguage(lang) {
   currentLang = lang;
@@ -179,6 +190,9 @@ function setLanguage(lang) {
       el.setAttribute('aria-label', translation);
     }
   });
+  if (languageSelect) {
+    languageSelect.value = lang;
+  }
   if (window.game && typeof window.game.updateUI === 'function') {
     window.game.updateUI();
   }


### PR DESCRIPTION
## Summary
- Detect browser language on page load and use it if translations exist
- Update language selector to reflect the active language

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b17307cf30832ca2af0a32fad5182e